### PR TITLE
EitherT refactor

### DIFF
--- a/haskell/src/ParseCNF.hs
+++ b/haskell/src/ParseCNF.hs
@@ -24,25 +24,25 @@ getKissSet file = do
 
 getKissData :: String -> EitherT T.Text IO CNFKissData
 getKissData file =
-    case parse parseCNFLines "KiSS CNF error: " (map toLower file) of
-      Right ls -> return $ linesToScript ls
-      Left e  -> EitherT $ return $ Left $ T.pack $ show e
+  case parse parseCNFLines "KiSS CNF error: " (map toLower file) of
+    Right ls -> right $ linesToScript ls
+    Left  e  -> left  $ T.pack $ show e
 
 getKissCels :: String -> EitherT T.Text IO [CNFKissCell]
 getKissCels file =
-    case parse parseCNFLines "KiSS cel error: " (map toLower file) of
-      Right ls -> return $ linesToCells ls
-      Left e  -> EitherT $ return $ Left $ T.pack $ show e
+  case parse parseCNFLines "KiSS cel error: " (map toLower file) of
+    Right ls -> right $ linesToCells ls
+    Left  e  -> left  $ T.pack $ show e
 
 getKissPalettes :: CNFKissData -> EitherT T.Text IO Palettes
-getKissPalettes file = return $ toArray (cnfkPalettes file)
+getKissPalettes file = right $ toArray (cnfkPalettes file)
   where toArray l = A.listArray (0, length l - 1) l
 
 lookupPalette :: Int -> Palettes -> EitherT T.Text IO PaletteFilename
 lookupPalette n palettes =
   if snd (A.bounds palettes) >= n
-    then return (palettes ! n)
-    else EitherT $ return $ Left "Palette not found"
+    then right (palettes ! n)
+    else left "Palette not found"
 
 defaultPalette :: Palettes -> EitherT T.Text IO PaletteFilename
 defaultPalette = lookupPalette 0

--- a/haskell/src/Shell.hs
+++ b/haskell/src/Shell.hs
@@ -15,13 +15,13 @@ import           ParseCNF
 -- Gets the transparency color from a kcf palette.
 transColor :: PaletteFilename -> EitherT T.Text IO String
 transColor paletteLoc = EitherT $ do
-  (_,colorOut, err, ph)  <- createProcess (shell $ "cel2pnm -t " <> paletteLoc) { std_out = CreatePipe, std_err = CreatePipe }
+  (_, colorOut, err, ph)  <- createProcess (shell $ "cel2pnm -t " <> paletteLoc) { std_out = CreatePipe, std_err = CreatePipe }
   result <- waitForProcess ph
   errMsg <- case err of
               Just x  -> hGetContents x
               Nothing -> return "no error message"
   color <- case colorOut of
-              Just x -> hGetContents x
+              Just x  -> hGetContents x
               Nothing -> return "no color"
   case result of
     ExitSuccess   -> return $ Right color

--- a/haskell/src/Upload.hs
+++ b/haskell/src/Upload.hs
@@ -96,11 +96,11 @@ tryIO m = EitherT $ first showIOException <$> try m
 -- for now, only looks at first cnf listed
 getCNF :: FilePath -> EitherT Text IO String
 getCNF dir = do
-  files <- liftIO $ getDirectoryContents dir
+  files <- tryIO $ getDirectoryContents dir
   let cnfs = filter (\x -> takeExtension x == ".cnf") files
   case cnfs of
-    (f:_fs) -> liftIO $ readUtf8OrShiftJis (dir </> f)
-    _ -> EitherT $ return $ Left "No configuration file found."
+    (f:_fs) -> tryIO $ readUtf8OrShiftJis (dir </> f)
+    _ -> left "No configuration file found."
 
 readUtf8OrShiftJis :: String -> IO String
 readUtf8OrShiftJis fp = do

--- a/haskell/src/Upload.hs
+++ b/haskell/src/Upload.hs
@@ -20,7 +20,7 @@ import           Control.Monad              (when)
 import           Control.Monad.IO.Class     (liftIO)
 import           Control.Monad.Trans.Either
 import           Data.Monoid                ((<>))
-import           Data.Bifunctor             (first)
+import           Data.Either.Combinators    (mapLeft)
 
 import           Data.Aeson                 (encode)
 
@@ -89,7 +89,7 @@ addCelsAndColorsToKissData (CNFKissData m _ p ws o) bgColor borderColor cels =
   KissData m borderColor bgColor p ws o cels
 
 tryIO :: IO a -> EitherT Text IO a
-tryIO m = EitherT $ first showIOException <$> try m
+tryIO m = EitherT $ mapLeft showIOException <$> try m
   where
     showIOException = T.pack . show :: IOException -> Text
 

--- a/haskell/src/Upload.hs
+++ b/haskell/src/Upload.hs
@@ -20,6 +20,7 @@ import           Control.Monad              (when)
 import           Control.Monad.IO.Class     (liftIO)
 import           Control.Monad.Trans.Either
 import           Data.Monoid                ((<>))
+import           Data.Bifunctor             (first)
 
 import           Data.Aeson                 (encode)
 
@@ -87,12 +88,10 @@ addCelsAndColorsToKissData :: CNFKissData -> Color -> Color -> [KissCell] -> Kis
 addCelsAndColorsToKissData (CNFKissData m _ p ws o) bgColor borderColor cels =
   KissData m borderColor bgColor p ws o cels
 
-tryIO :: IO () -> EitherT Text IO ()
-tryIO f = do
-  result <-liftIO (try f :: IO (Either IOException ()))
-  case result of
-    Right () -> return ()
-    Left ex  -> EitherT $ return $ Left (T.pack $ show ex)
+tryIO :: IO a -> EitherT Text IO a
+tryIO m = EitherT $ first showIOException <$> try m
+  where
+    showIOException = T.pack . show :: IOException -> Text
 
 -- for now, only looks at first cnf listed
 getCNF :: FilePath -> EitherT Text IO String

--- a/haskell/src/Web.hs
+++ b/haskell/src/Web.hs
@@ -6,7 +6,6 @@ module Web where
 
 import           Control.Lens
 import           Control.Logging
-import           Control.Monad.IO.Class     (liftIO)
 import           Control.Monad.Trans.Either
 import           Data.Map.Syntax            (MapSyntaxM, ( ## ))
 import           Data.Monoid                ((<>))
@@ -61,13 +60,13 @@ indexHandler ctxt = render ctxt "index"
 uploadHandler :: Ctxt -> File -> IO (Maybe Response)
 uploadHandler ctxt (File name _ filePath') = do
   let staticDir = staticDirFromSetName (takeBaseName (T.unpack name))
-  cels <- liftIO $ runEitherT $ processSet (T.unpack name, filePath')
+  cels <- runEitherT $ processSet (T.unpack name, filePath')
   renderKissSet ctxt staticDir cels
 
 setHandler :: Ctxt -> T.Text -> IO (Maybe Response)
 setHandler ctxt setName = do
   let staticDir = staticDirFromSetName (T.unpack setName)
-  cels <- liftIO $ runEitherT $ createCels staticDir
+  cels <- runEitherT $ createCels staticDir
   renderKissSet ctxt staticDir cels
 
 renderKissSet :: Ctxt -> String -> Either T.Text [KissCell] -> IO (Maybe Response)


### PR DESCRIPTION
I coded up the changes! :man_technologist: ☕️ 

In the process I discovered that the package `either` depends on the package `bifunctors` which implements handy functions like [`first`](http://hackage.haskell.org/package/bifunctors-3.0/docs/src/Data-Bifunctor.html).

I thought I'd use that instead of [`mapLeft`](http://hackage.haskell.org/package/either-4.4.1.1/docs/src/Data.Either.Combinators.html#mapLeft) I had found before in [`Data.Either.Combinators`](http://hackage.haskell.org/package/either-4.4.1.1/docs/Data-Either-Combinators.html) (also from `either` but whose documentation says, quote: _Most of these combinators are provided for pedagogical purposes and exist in more general forms in other libraries._ Go figure!)

Let me know what you think! 🌠
