### PR TITLE
Add dolls to users

### DIFF
--- a/app/smooch.cabal
+++ b/app/smooch.cabal
@@ -50,6 +50,8 @@ library
                        Web,
                        Ctxt,
                        Session,
+                       Sets.Controller,
+                       Sets.View,
                        Users.Model,
                        Users.View,
                        Users.Controller

--- a/app/src/Ctxt.hs
+++ b/app/src/Ctxt.hs
@@ -28,6 +28,8 @@ makeLenses ''Ctxt
 instance RequestContext Ctxt where
   requestLens = req
 
+type Handler k = Ctxt -> k -> IO (Maybe Response)
+
 renderWith :: Ctxt -> Path -> Substitutions Ctxt -> IO (Maybe Response)
 renderWith ctxt tplPath addSubs = do
   mRendered <- L.renderWith (ctxt ^. library)

--- a/app/src/Ctxt.hs
+++ b/app/src/Ctxt.hs
@@ -28,8 +28,6 @@ makeLenses ''Ctxt
 instance RequestContext Ctxt where
   requestLens = req
 
-type Handler k = Ctxt -> k -> IO (Maybe Response)
-
 renderWith :: Ctxt -> Path -> Substitutions Ctxt -> IO (Maybe Response)
 renderWith ctxt tplPath addSubs = do
   mRendered <- L.renderWith (ctxt ^. library)

--- a/app/src/Session.hs
+++ b/app/src/Session.hs
@@ -1,23 +1,16 @@
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Session where
 
 import           Control.Lens            ((^.))
-import           Control.Monad.State     (StateT, get, liftIO)
-import           Data.Monoid             ((<>))
 import           Data.Text               (Text)
 import qualified Data.Vault.Lazy         as V
-import           Network.Wai             (Middleware, Response, vault)
+import           Network.Wai             (Middleware, vault)
 import           Network.Wai.Session     (genSessionId, withSession)
 import           Network.Wai.Session.Map (mapStore)
 import           Web.Cookie              (def)
-import           Web.Fn
-import           Web.Larceny             hiding (renderWith)
 
 import           Ctxt
-import           Users.Model
 
 sessionMiddleware :: V.Key SmoochSession -> IO Middleware
 sessionMiddleware vaultKey = do
@@ -32,33 +25,10 @@ setInSession :: Ctxt -> Text -> Text -> IO ()
 setInSession ctxt k v =
   case lookupSession ctxt of
     Just (_, setSession) -> setSession k v
-    Nothing -> error $ "setInSession: no session in vault"
+    Nothing -> error "setInSession: no session in vault"
 
 getFromSession :: Ctxt -> Text -> IO (Maybe Text)
 getFromSession ctxt k =
   case lookupSession ctxt of
     Just (getSession, _) -> getSession k
-    Nothing -> error $ "getFromSession: no session in vault"
-
-loginHandler :: Ctxt -> Text -> Text ->IO (Maybe Response)
-loginHandler ctxt username password = do
-  mUser <- authenticateUser ctxt username password
-  case mUser of
-    Just _user -> do
-      setInSession ctxt "user" username
-      mLoggedInUser <- getFromSession ctxt "user"
-      case mLoggedInUser of
-        Just user -> okText $ user <> " is logged in!"
-        Nothing -> okText "you're logged in!!! (lie)"
-    Nothing    -> errText "Your username or password was wrong :("
-
-loggedInUserSplices :: Substitutions Ctxt
-loggedInUserSplices =
-  subs [("loggedInUser", textFill' userFill)]
-  where userFill :: StateT Ctxt IO Text
-        userFill = do
-          ctxt <- get
-          mUser <- liftIO $ getFromSession ctxt "user"
-          case mUser of
-            Just user -> return user
-            Nothing -> return ""
+    Nothing -> error "getFromSession: no session in vault"

--- a/app/src/Sets/Controller.hs
+++ b/app/src/Sets/Controller.hs
@@ -12,11 +12,19 @@ import           Ctxt
 import           Kiss
 import           Sets.View
 import           Upload
+import           Users.Model
 
 uploadHandler :: Ctxt -> File -> IO (Maybe Response)
 uploadHandler ctxt (File name _ filePath') = do
   let staticDir = staticDirFromSetName (takeBaseName (T.unpack name))
   cels <- runEitherT $ processSet (T.unpack name, filePath')
+  renderKissSet ctxt staticDir cels
+
+userUploadHandler :: User -> Ctxt -> File -> IO (Maybe Response)
+userUploadHandler user ctxt (File name _ filePath') = do
+  let staticDir = staticDirFromSetName (takeBaseName (T.unpack name))
+  cels <- runEitherT $ processUserSet (userUsername user)
+                                      (T.unpack name, filePath')
   renderKissSet ctxt staticDir cels
 
 setHandler :: Ctxt -> T.Text -> IO (Maybe Response)

--- a/app/src/Sets/Controller.hs
+++ b/app/src/Sets/Controller.hs
@@ -32,6 +32,13 @@ setHandler ctxt setName = do
   cels <- runEitherT $ createCels staticDir
   renderKissSet ctxt staticDir cels
 
+userSetHandler :: User -> Ctxt -> T.Text -> IO (Maybe Response)
+userSetHandler user ctxt setName = do
+  let userDir = staticUserDir (userUsername user)
+  let staticDir = staticUserSetDir userDir (T.unpack setName)
+  cels <- runEitherT $ createCels staticDir
+  renderKissSet ctxt staticDir cels
+
 renderKissSet :: Ctxt -> String -> Either T.Text [KissCell] -> IO (Maybe Response)
 renderKissSet ctxt staticDir cels =
   case cels of

--- a/app/src/Sets/Controller.hs
+++ b/app/src/Sets/Controller.hs
@@ -15,14 +15,14 @@ import           Users.Model
 
 userUploadHandler :: User -> Ctxt -> File -> IO (Maybe Response)
 userUploadHandler user ctxt (File name _ filePath') = do
-  output <- runEitherT $ processUserSet (userUsername user)
-                                        (T.unpack name, filePath')
-  renderKissSet' ctxt output
+  output <- runEitherT $ processSet (userUsername user)
+                                    (T.unpack name, filePath')
+  renderKissSet ctxt output
 
 userSetHandler :: User -> Ctxt -> T.Text -> IO (Maybe Response)
 userSetHandler user ctxt setName = do
   let userDir = staticUserDir (userUsername user)
-  let staticDir = staticUserSetDir userDir (T.unpack setName)
+  let staticDir = staticSetDir userDir (T.unpack setName)
   output <- (fmap . fmap) ((,) staticDir) (runEitherT $ createCels staticDir)
   -- The previous line is a bit weird.
   -- the result of runEitherT is an `IO (Either Text [KissCell])`.
@@ -31,10 +31,10 @@ userSetHandler user ctxt setName = do
   -- `(fmap . fmap)` let's us map into two layers of functions -- first the
   -- IO functor, then then Either functor. This makes the Right side of
   -- the Either a tuple! Whew.
-  renderKissSet' ctxt output
+  renderKissSet ctxt output
 
-renderKissSet' :: Ctxt -> Either T.Text (FilePath, [KissCell]) -> IO (Maybe Response)
-renderKissSet' ctxt eOutputError =
+renderKissSet :: Ctxt -> Either T.Text (FilePath, [KissCell]) -> IO (Maybe Response)
+renderKissSet ctxt eOutputError =
   case eOutputError of
     Right (staticDir, cels) ->
       renderWith ctxt ["users", "kiss-set"] $ setSplices staticDir cels

--- a/app/src/Sets/Controller.hs
+++ b/app/src/Sets/Controller.hs
@@ -22,10 +22,12 @@ uploadHandler ctxt (File name _ filePath') = do
 
 userUploadHandler :: User -> Ctxt -> File -> IO (Maybe Response)
 userUploadHandler user ctxt (File name _ filePath') = do
-  let staticDir = staticDirFromSetName (takeBaseName (T.unpack name))
-  cels <- runEitherT $ processUserSet (userUsername user)
+  let username = userUsername user
+  let userDir = staticUserDir username
+  let staticDir = staticUserSetDir userDir (takeBaseName (T.unpack name))
+  cels <- runEitherT $ processUserSet username
                                       (T.unpack name, filePath')
-  renderKissSet ctxt staticDir cels
+  renderKissSet' ctxt staticDir cels
 
 setHandler :: Ctxt -> T.Text -> IO (Maybe Response)
 setHandler ctxt setName = do
@@ -37,4 +39,10 @@ renderKissSet :: Ctxt -> String -> Either T.Text [KissCell] -> IO (Maybe Respons
 renderKissSet ctxt staticDir cels =
   case cels of
     Right cs -> renderWith ctxt ["kissSet"] $ setSplices staticDir cs
-    Left  e -> okText e
+    Left  e -> errText e
+
+renderKissSet' :: Ctxt -> String -> Either T.Text [KissCell] -> IO (Maybe Response)
+renderKissSet' ctxt staticDir cels =
+  case cels of
+    Right cs -> renderWith ctxt ["users", "kissSet"] $ setSplices staticDir cs
+    Left  e -> errText e

--- a/app/src/Sets/Controller.hs
+++ b/app/src/Sets/Controller.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Sets.Controller where
+
+import           Control.Monad.Trans.Either (runEitherT)
+import qualified Data.Text                  as T
+import           Network.Wai                (Response)
+import           System.FilePath            (takeBaseName)
+import           Web.Fn
+
+import           Ctxt
+import           Kiss
+import           Sets.View
+import           Upload
+
+uploadHandler :: Ctxt -> File -> IO (Maybe Response)
+uploadHandler ctxt (File name _ filePath') = do
+  let staticDir = staticDirFromSetName (takeBaseName (T.unpack name))
+  cels <- runEitherT $ processSet (T.unpack name, filePath')
+  renderKissSet ctxt staticDir cels
+
+setHandler :: Ctxt -> T.Text -> IO (Maybe Response)
+setHandler ctxt setName = do
+  let staticDir = staticDirFromSetName (T.unpack setName)
+  cels <- runEitherT $ createCels staticDir
+  renderKissSet ctxt staticDir cels
+
+renderKissSet :: Ctxt -> String -> Either T.Text [KissCell] -> IO (Maybe Response)
+renderKissSet ctxt staticDir cels =
+  case cels of
+    Right cs -> renderWith ctxt ["kissSet"] $ setSplices staticDir cs
+    Left  e -> okText e

--- a/app/src/Sets/Controller.hs
+++ b/app/src/Sets/Controller.hs
@@ -14,23 +14,12 @@ import           Sets.View
 import           Upload
 import           Users.Model
 
-uploadHandler :: Ctxt -> File -> IO (Maybe Response)
-uploadHandler ctxt (File name _ filePath') = do
-  let staticDir = staticDirFromSetName (takeBaseName (T.unpack name))
-  cels <- runEitherT $ processSet (T.unpack name, filePath')
-  renderKissSet ctxt staticDir cels
-
 userUploadHandler :: User -> Ctxt -> File -> IO (Maybe Response)
 userUploadHandler user ctxt (File name _ filePath') = do
   output <- runEitherT $ processUserSet (userUsername user)
                                         (T.unpack name, filePath')
   renderKissSet' ctxt output
 
-setHandler :: Ctxt -> T.Text -> IO (Maybe Response)
-setHandler ctxt setName = do
-  let staticDir = staticDirFromSetName (T.unpack setName)
-  cels <- runEitherT $ createCels staticDir
-  renderKissSet ctxt staticDir cels
 
 userSetHandler :: User -> Ctxt -> T.Text -> IO (Maybe Response)
 userSetHandler user ctxt setName = do
@@ -45,13 +34,6 @@ userSetHandler user ctxt setName = do
   -- IO functor, then then Either functor. This makes the Right side of
   -- the Either a tuple! Whew.
   renderKissSet' ctxt output
-
-
-renderKissSet :: Ctxt -> String -> Either T.Text [KissCell] -> IO (Maybe Response)
-renderKissSet ctxt staticDir cels =
-  case cels of
-    Right cs -> renderWith ctxt ["kissSet"] $ setSplices staticDir cs
-    Left  e -> errText e
 
 renderKissSet' :: Ctxt -> Either T.Text (FilePath, [KissCell]) -> IO (Maybe Response)
 renderKissSet' ctxt eOutputError =

--- a/app/src/Sets/View.hs
+++ b/app/src/Sets/View.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Sets.View where
+
+import qualified Data.Text   as T
+import           Web.Larceny
+
+import           Ctxt
+import           Kiss
+
+setSplices :: String -> [KissCell] -> Substitutions Ctxt
+setSplices staticDir cs =
+  subs [("set-listing", setListingSplice),
+        ("base", textFill (T.pack staticDir)),
+        ("celImages", celsSplice staticDir cs)]
+
+setListingSplice :: Fill Ctxt
+setListingSplice =
+  mapSubs toSet ([0..9] :: [Int])
+  where toSet n =
+          subs [("set-number", (textFill . T.pack . show) n)]
+
+celsSplice :: FilePath -> [KissCell] -> Fill Ctxt
+celsSplice dir cels =
+  mapSubs (celImageSplice dir) (reverse cels)
+
+celImageSplice :: FilePath -> KissCell -> Substitutions Ctxt
+celImageSplice dir cel =
+  subs [("cel-name", textFill $ T.pack $ celName cel)
+       ,("dir", textFill $ T.pack dir)]

--- a/app/src/Upload.hs
+++ b/app/src/Upload.hs
@@ -39,14 +39,15 @@ processSet (fName, filePath) = do
 
 processUserSet :: Text
                -> (FilePath, FilePath)
-               -> EitherT Text IO [KissCell]
+               -> EitherT Text IO (FilePath, [KissCell])
 processUserSet username (fName, filePath) = do
   tryIO $ copyFile filePath ("static/sets" </> fName)
   userDir <- createUserDir username
   staticDir <- createSetDir' userDir (takeBaseName fName)
   unzipFile fName staticDir
   log' "Unzipped file!"
-  createCels staticDir
+  cels <- createCels staticDir
+  return (staticDir, cels)
 
 staticDirFromSetName :: String -> FilePath
 staticDirFromSetName setName = "static/sets/" <> setName

--- a/app/src/Upload.hs
+++ b/app/src/Upload.hs
@@ -29,37 +29,17 @@ import           Kiss
 import           ParseCNF
 import           Shell
 
-processSet :: (FilePath, FilePath) -> EitherT Text IO [KissCell]
-processSet (fName, filePath) = do
-  tryIO $ copyFile filePath ("static/sets" </> fName)
-  staticDir <- createSetDir (takeBaseName fName)
-  unzipFile fName staticDir
-  log' "Unzipped file!"
-  createCels staticDir
-
-processUserSet :: Text
-               -> (FilePath, FilePath)
-               -> EitherT Text IO (FilePath, [KissCell])
-processUserSet username (fName, filePath) = do
+processSet :: Text
+           -> (FilePath, FilePath)
+           -> EitherT Text IO (FilePath, [KissCell])
+processSet username (fName, filePath) = do
   tryIO $ copyFile filePath ("static/sets" </> fName)
   userDir <- createUserDir username
-  staticDir <- createSetDir' userDir (takeBaseName fName)
+  staticDir <- createSetDir userDir (takeBaseName fName)
   unzipFile fName staticDir
   log' "Unzipped file!"
   cels <- createCels staticDir
   return (staticDir, cels)
-
-staticDirFromSetName :: String -> FilePath
-staticDirFromSetName setName = "static/sets/" <> setName
-
-createSetDir :: String -> EitherT Text IO FilePath
-createSetDir setName = do
-  let staticDir = "static/sets/" <> setName
-  exists <- liftIO $ doesDirectoryExist staticDir
-  when exists $ tryIO $ removeDirectoryRecursive staticDir
-  tryIO $ createDirectory staticDir
-  log' $ "Created static directory: " <> T.pack staticDir
-  return staticDir
 
 staticUserDir :: Text -> FilePath
 staticUserDir username = "static/sets/" <> T.unpack username
@@ -71,11 +51,11 @@ createUserDir username = do
   log' $ "Created static user sets directory if missing: " <> T.pack staticDir
   return staticDir
 
-staticUserSetDir :: FilePath -> String -> FilePath
-staticUserSetDir userDir setName =  userDir <> "/" <> setName
+staticSetDir :: FilePath -> String -> FilePath
+staticSetDir userDir setName =  userDir <> "/" <> setName
 
-createSetDir' :: FilePath -> String -> EitherT Text IO FilePath
-createSetDir' userDir setName = do
+createSetDir :: FilePath -> String -> EitherT Text IO FilePath
+createSetDir userDir setName = do
   let staticDir = userDir <> "/" <> setName
   exists <- liftIO $ doesDirectoryExist staticDir
   when exists $ tryIO $ removeDirectoryRecursive staticDir

--- a/app/src/Upload.hs
+++ b/app/src/Upload.hs
@@ -4,9 +4,9 @@
 
 module Upload where
 
-import           Data.List                  (nub)
 import qualified Data.ByteString            as BS
 import qualified Data.ByteString.Lazy       as LBS
+import           Data.List                  (nub)
 import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
@@ -20,8 +20,8 @@ import           Control.Logging            (log')
 import           Control.Monad              (when)
 import           Control.Monad.IO.Class     (liftIO)
 import           Control.Monad.Trans.Either
-import           Data.Monoid                ((<>))
 import           Data.Either.Combinators    (mapLeft)
+import           Data.Monoid                ((<>))
 
 import           Data.Aeson                 (encode)
 
@@ -31,6 +31,16 @@ import           Shell
 
 processSet :: (FilePath, FilePath) -> EitherT Text IO [KissCell]
 processSet (fName, filePath) = do
+  tryIO $ copyFile filePath ("static/sets" </> fName)
+  staticDir <- createSetDir (takeBaseName fName)
+  unzipFile fName staticDir
+  log' "Unzipped file!"
+  createCels staticDir
+
+processUserSet :: Text
+               -> (FilePath, FilePath)
+               -> EitherT Text IO [KissCell]
+processUserSet username (fName, filePath) = do
   tryIO $ copyFile filePath ("static/sets" </> fName)
   staticDir <- createSetDir (takeBaseName fName)
   unzipFile fName staticDir

--- a/app/src/Upload.hs
+++ b/app/src/Upload.hs
@@ -43,7 +43,7 @@ processUserSet :: Text
 processUserSet username (fName, filePath) = do
   tryIO $ copyFile filePath ("static/sets" </> fName)
   userDir <- createUserDir username
-  staticDir <- createSetDir (takeBaseName fName)
+  staticDir <- createSetDir' userDir (takeBaseName fName)
   unzipFile fName staticDir
   log' "Unzipped file!"
   createCels staticDir
@@ -57,7 +57,7 @@ createSetDir setName = do
   exists <- liftIO $ doesDirectoryExist staticDir
   when exists $ tryIO $ removeDirectoryRecursive staticDir
   tryIO $ createDirectory staticDir
-  log' $ "Created static directory if missing: " <> T.pack staticDir
+  log' $ "Created static directory: " <> T.pack staticDir
   return staticDir
 
 staticUserDir :: Text -> FilePath
@@ -67,7 +67,19 @@ createUserDir :: Text -> EitherT Text IO FilePath
 createUserDir username = do
   let staticDir = staticUserDir username
   tryIO $ createDirectoryIfMissing True staticDir
-  log' $ "Created static user sets directory: " <> T.pack staticDir
+  log' $ "Created static user sets directory if missing: " <> T.pack staticDir
+  return staticDir
+
+staticUserSetDir :: FilePath -> String -> FilePath
+staticUserSetDir userDir setName =  userDir <> "/" <> setName
+
+createSetDir' :: FilePath -> String -> EitherT Text IO FilePath
+createSetDir' userDir setName = do
+  let staticDir = userDir <> "/" <> setName
+  exists <- liftIO $ doesDirectoryExist staticDir
+  when exists $ tryIO $ removeDirectoryRecursive staticDir
+  tryIO $ createDirectory staticDir
+  log' $ "Created static directory: " <> T.pack staticDir
   return staticDir
 
 deleteCels :: FilePath -> IO ()

--- a/app/src/Upload.hs
+++ b/app/src/Upload.hs
@@ -42,6 +42,7 @@ processUserSet :: Text
                -> EitherT Text IO [KissCell]
 processUserSet username (fName, filePath) = do
   tryIO $ copyFile filePath ("static/sets" </> fName)
+  userDir <- createUserDir username
   staticDir <- createSetDir (takeBaseName fName)
   unzipFile fName staticDir
   log' "Unzipped file!"
@@ -56,7 +57,17 @@ createSetDir setName = do
   exists <- liftIO $ doesDirectoryExist staticDir
   when exists $ tryIO $ removeDirectoryRecursive staticDir
   tryIO $ createDirectory staticDir
-  log' $ "Created static directory: " <> T.pack staticDir
+  log' $ "Created static directory if missing: " <> T.pack staticDir
+  return staticDir
+
+staticUserDir :: Text -> FilePath
+staticUserDir username = "static/sets/" <> T.unpack username
+
+createUserDir :: Text -> EitherT Text IO FilePath
+createUserDir username = do
+  let staticDir = staticUserDir username
+  tryIO $ createDirectoryIfMissing True staticDir
+  log' $ "Created static user sets directory: " <> T.pack staticDir
   return staticDir
 
 deleteCels :: FilePath -> IO ()

--- a/app/src/Users/Controller.hs
+++ b/app/src/Users/Controller.hs
@@ -46,9 +46,9 @@ requireAuthentication handler = \ctxt k -> do
     Nothing -> errText "you're not logged in"
 
 userHandler :: Ctxt -> User -> Text -> IO (Maybe Response)
-userHandler _ctxt loggedInUser username = do
+userHandler ctxt loggedInUser username = do
   if userUsername loggedInUser == username
-    then okText "this is your settings page"
+    then renderWith ctxt ["users", "show"] (userSplices loggedInUser)
     else return Nothing
 
 usersCreateHandler :: Ctxt -> Text -> Text -> Text -> Text -> IO (Maybe Response)

--- a/app/src/Users/Controller.hs
+++ b/app/src/Users/Controller.hs
@@ -52,7 +52,10 @@ loggedInUserRoutes ctxt loggedInUser username = do
     then route ctxt [ end ==> userHandler loggedInUser
                     , path "upload" // method POST
                                     // file "kissfile"
-                                    !=> userUploadHandler loggedInUser ]
+                                    !=> userUploadHandler loggedInUser
+                    , path "sets" // segment
+                                  // end
+                                  ==> userSetHandler loggedInUser ]
     else return Nothing
 
 userHandler ::  User -> Ctxt -> IO (Maybe Response)

--- a/app/src/Users/Controller.hs
+++ b/app/src/Users/Controller.hs
@@ -22,7 +22,22 @@ userRoutes ctxt =
                             // param "username"
                             // param "email"
                             // param "password"
-                            // param "password-confirmation" !=> usersCreateHandler)]
+                            // param "password-confirmation" !=> usersCreateHandler)
+             , (segment ==> requireAuthentication userHandler )]
+
+userHandler :: Ctxt -> Text -> IO (Maybe Response)
+userHandler ctxt username = do
+  mUser <- getUserByUsername ctxt username
+  case mUser of
+    Just _user -> okText "this is your settings page"
+    Nothing -> errText "User not found"
+
+requireAuthentication :: Handler k -> Handler k
+requireAuthentication handler = \ctxt k -> do
+  mUser <- getLoggedInUser ctxt
+  case mUser of
+    Just _user -> handler ctxt k
+    Nothing -> errText "you're not logged in"
 
 usersHandler :: Ctxt -> IO (Maybe Response)
 usersHandler ctxt = do

--- a/app/src/Users/Controller.hs
+++ b/app/src/Users/Controller.hs
@@ -15,8 +15,8 @@ import           Ctxt
 import           Users.Model
 import           Users.View
 
-userRoutes :: Ctxt -> IO (Maybe Response)
-userRoutes ctxt =
+usersRoutes :: Ctxt -> IO (Maybe Response)
+usersRoutes ctxt =
   route ctxt [ (end ==> usersHandler)
              , (method POST // path "create"
                             // param "username"
@@ -24,6 +24,8 @@ userRoutes ctxt =
                             // param "password"
                             // param "password-confirmation" !=> usersCreateHandler)
              , (segment ==> requireAuthentication userHandler )]
+
+
 
 usersHandler :: Ctxt -> IO (Maybe Response)
 usersHandler ctxt = do

--- a/app/src/Users/Controller.hs
+++ b/app/src/Users/Controller.hs
@@ -23,9 +23,7 @@ usersRoutes ctxt =
                             // param "email"
                             // param "password"
                             // param "password-confirmation" !=> usersCreateHandler)
-             , (segment ==> requireAuthentication userHandler )]
-
-
+             , (segment ==> requireAuthentication loggedInUserRoutes)]
 
 usersHandler :: Ctxt -> IO (Maybe Response)
 usersHandler ctxt = do
@@ -47,11 +45,15 @@ requireAuthentication handler = \ctxt k -> do
     Just user -> handler ctxt user k
     Nothing -> errText "you're not logged in"
 
-userHandler :: Ctxt -> User -> Text -> IO (Maybe Response)
-userHandler ctxt loggedInUser username = do
+loggedInUserRoutes :: Ctxt -> User -> Text -> IO (Maybe Response)
+loggedInUserRoutes ctxt loggedInUser username = do
   if userUsername loggedInUser == username
-    then renderWith ctxt ["users", "show"] (userSplices loggedInUser)
+    then route ctxt [ (end ==> userHandler loggedInUser)]
     else return Nothing
+
+userHandler ::  User -> Ctxt -> IO (Maybe Response)
+userHandler loggedInUser ctxt = do
+  renderWith ctxt ["users", "show"] (userSplices loggedInUser)
 
 usersCreateHandler :: Ctxt -> Text -> Text -> Text -> Text -> IO (Maybe Response)
 usersCreateHandler ctxt username email password passwordConfirmation = do

--- a/app/src/Users/Controller.hs
+++ b/app/src/Users/Controller.hs
@@ -12,6 +12,7 @@ import           Web.Fn
 import           Web.Larceny        hiding (renderWith)
 
 import           Ctxt
+import           Sets.Controller
 import           Users.Model
 import           Users.View
 
@@ -48,7 +49,10 @@ requireAuthentication handler = \ctxt k -> do
 loggedInUserRoutes :: Ctxt -> User -> Text -> IO (Maybe Response)
 loggedInUserRoutes ctxt loggedInUser username = do
   if userUsername loggedInUser == username
-    then route ctxt [ (end ==> userHandler loggedInUser)]
+    then route ctxt [ end ==> userHandler loggedInUser
+                    , path "upload" // method POST
+                                    // file "kissfile"
+                                    !=> userUploadHandler loggedInUser ]
     else return Nothing
 
 userHandler ::  User -> Ctxt -> IO (Maybe Response)

--- a/app/src/Users/Model.hs
+++ b/app/src/Users/Model.hs
@@ -3,7 +3,6 @@
 module Users.Model where
 
 import           Control.Lens                       ((^.))
-import           Data.Int                           (Int64)
 import           Data.Maybe                         (listToMaybe)
 import           Data.Pool                          (withResource)
 import           Data.Text                          (Text)
@@ -14,6 +13,7 @@ import           Database.PostgreSQL.Simple.ToField
 import           Database.PostgreSQL.Simple.ToRow
 
 import           Ctxt
+import           Session
 
 data User = User { userId        :: Int
                  , userUsername  :: Text
@@ -81,3 +81,14 @@ getUserByEmail ctxt email = listToMaybe <$>
      \ WHERE email = ?"
      (PG.Only email)
        :: IO [ User ])
+
+getLoggedInUser :: Ctxt -> IO (Maybe User)
+getLoggedInUser ctxt = do
+  mUsername <- getFromSession ctxt "user"
+  case mUsername of
+    Just username -> getUserByUsername ctxt username
+    Nothing -> return Nothing
+
+setLoggedInUser :: Ctxt -> User -> IO ()
+setLoggedInUser ctxt user = do
+  setInSession ctxt "user" (userUsername user)

--- a/app/src/Users/View.hs
+++ b/app/src/Users/View.hs
@@ -2,7 +2,8 @@
 
 module Users.View where
 
-import qualified Data.Text   as T
+import           Control.Monad.State (get, liftIO)
+import qualified Data.Text           as T
 import           Data.Time
 import           Web.Larceny
 
@@ -19,6 +20,16 @@ userSplices user = subs
   ,("email", textFill (userEmail user))
   ,("created-at", dateSplice (userCreatedAt user))
   ,("updated-at", dateSplice (userUpdatedAt user))]
+
+loggedInUserSplices :: Substitutions Ctxt
+loggedInUserSplices =
+  subs [("loggedInUser", userFill)]
+  where userFill = fillChildrenWith' $ do
+          ctxt <- get
+          mUser <- liftIO $ getLoggedInUser ctxt
+          case mUser of
+            Just user -> return $ userSplices user
+            Nothing -> return mempty
 
 dateSplice :: UTCTime -> Fill Ctxt
 dateSplice = textFill . formatTimestamp

--- a/app/src/Web.hs
+++ b/app/src/Web.hs
@@ -17,7 +17,6 @@ import           Web.Larceny                hiding (renderWith)
 
 import           Ctxt
 import           Session
-import           Sets.Controller
 import           Users.Controller
 import           Users.Model
 import           Users.View

--- a/app/src/Web.hs
+++ b/app/src/Web.hs
@@ -69,7 +69,7 @@ site ctxt =
              , method POST // path "login"
                            // param "username"
                            // param "password" !=> loginHandler
-             , path "users" ==> userRoutes
+             , path "users" ==> usersRoutes
              , path "static" // anything ==> staticServe "static" ]
     `fallthrough` notFoundText "Page not found."
 

--- a/app/src/Web.hs
+++ b/app/src/Web.hs
@@ -9,6 +9,7 @@ import           Control.Monad.Trans.Either (runEitherT)
 import qualified Data.Configurator          as C
 import           Data.Monoid                ((<>))
 import           Data.Pool                  (createPool)
+import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import qualified Data.Vault.Lazy            as V
 import qualified Database.PostgreSQL.Simple as PG
@@ -24,6 +25,8 @@ import           Kiss
 import           Session
 import           Upload
 import           Users.Controller
+import           Users.Model
+import           Users.View
 
 initializer :: IO Ctxt
 initializer = do
@@ -72,6 +75,15 @@ site ctxt =
 
 indexHandler :: Ctxt -> IO (Maybe Response)
 indexHandler ctxt = renderWith ctxt ["index"] (createUserErrorSplices <> loggedInUserSplices)
+
+loginHandler :: Ctxt -> Text -> Text ->IO (Maybe Response)
+loginHandler ctxt username password = do
+  mUser <- authenticateUser ctxt username password
+  case mUser of
+    Just user -> do
+      setLoggedInUser ctxt user
+      okText $ userUsername user <> " is logged in!"
+    Nothing    -> errText "Your username or password was wrong :("
 
 uploadHandler :: Ctxt -> File -> IO (Maybe Response)
 uploadHandler ctxt (File name _ filePath') = do

--- a/app/src/Web.hs
+++ b/app/src/Web.hs
@@ -58,8 +58,6 @@ appBase ctxt = do
 site :: Ctxt -> IO Response
 site ctxt =
   route ctxt [ end ==> indexHandler
-             , path "upload" // method POST // file "kissfile" !=> uploadHandler
-             , path "sets" // segment // end ==> setHandler
              , method POST // path "login"
                            // param "username"
                            // param "password" !=> loginHandler

--- a/app/src/Web.hs
+++ b/app/src/Web.hs
@@ -1,29 +1,23 @@
-{-# LANGUAGE OverloadedStrings   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Web where
 
 import           Control.Lens               ((^.))
-import           Control.Monad.Trans.Either (runEitherT)
 import qualified Data.Configurator          as C
 import           Data.Monoid                ((<>))
 import           Data.Pool                  (createPool)
 import           Data.Text                  (Text)
-import qualified Data.Text                  as T
 import qualified Data.Vault.Lazy            as V
 import qualified Database.PostgreSQL.Simple as PG
 import           Network.HTTP.Types.Method  (StdMethod (..))
 import           Network.Wai                (Application, Response)
 import           System.Environment         (getEnv)
-import           System.FilePath            (takeBaseName)
 import           Web.Fn
 import           Web.Larceny                hiding (renderWith)
 
 import           Ctxt
-import           Kiss
 import           Session
-import           Upload
+import           Sets.Controller
 import           Users.Controller
 import           Users.Model
 import           Users.View
@@ -84,42 +78,3 @@ loginHandler ctxt username password = do
       setLoggedInUser ctxt user
       okText $ userUsername user <> " is logged in!"
     Nothing    -> errText "Your username or password was wrong :("
-
-uploadHandler :: Ctxt -> File -> IO (Maybe Response)
-uploadHandler ctxt (File name _ filePath') = do
-  let staticDir = staticDirFromSetName (takeBaseName (T.unpack name))
-  cels <- runEitherT $ processSet (T.unpack name, filePath')
-  renderKissSet ctxt staticDir cels
-
-setHandler :: Ctxt -> T.Text -> IO (Maybe Response)
-setHandler ctxt setName = do
-  let staticDir = staticDirFromSetName (T.unpack setName)
-  cels <- runEitherT $ createCels staticDir
-  renderKissSet ctxt staticDir cels
-
-renderKissSet :: Ctxt -> String -> Either T.Text [KissCell] -> IO (Maybe Response)
-renderKissSet ctxt staticDir cels =
-  case cels of
-    Right cs -> renderWith ctxt ["kissSet"] $ setSplices staticDir cs
-    Left  e -> okText e
-
-setSplices :: String -> [KissCell] -> Substitutions Ctxt
-setSplices staticDir cs =
-  subs [("set-listing", setListingSplice),
-        ("base", textFill (T.pack staticDir)),
-        ("celImages", celsSplice staticDir cs)]
-
-setListingSplice :: Fill Ctxt
-setListingSplice =
-  mapSubs toSet ([0..9] :: [Int])
-  where toSet n =
-          subs [("set-number", (textFill . T.pack . show) n)]
-
-celsSplice :: FilePath -> [KissCell] -> Fill Ctxt
-celsSplice dir cels =
-  mapSubs (celImageSplice dir) (reverse cels)
-
-celImageSplice :: FilePath -> KissCell -> Substitutions Ctxt
-celImageSplice dir cel =
-  subs [("cel-name", textFill $ T.pack $ celName cel)
-       ,("dir", textFill $ T.pack dir)]

--- a/app/templates/index.tpl
+++ b/app/templates/index.tpl
@@ -61,17 +61,5 @@
 
       <input type="submit" />
     </form>
-
-    <h2>Upload and play with a KiSS set </h2>
-
-    <p> Eventually this form will be under the user account page, but that's not ready yet.</p>
-
-    <form action="/upload" method="post" enctype="multipart/form-data">
-
-      <input type="file" name="kissfile">
-      <input type="submit" value="Upload!">
-
-    </form>
-
   </body>
 </html>

--- a/app/templates/users/kiss-set.tpl
+++ b/app/templates/users/kiss-set.tpl
@@ -1,0 +1,50 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Smooch</title>
+    <link rel="stylesheet" type="text/css" href="/static/screen.css">
+    <script type="text/javascript">
+     window.onload = function () {
+       document.getElementById('loading').style.display = 'none';
+     };
+    </script>
+  </head>
+  <body>
+    <div id="wrapper">
+    <div id="loading">
+      <p>Loading...</p>
+      <progress></progress>
+    </div>
+
+    <div id="sets">
+      <ul>
+        <set-listing>
+          <li><a class="set"><set-number /></a></li>
+        </set-listing>
+      </ul>
+      <p>Click through the set by choosing a number.</p>
+    </div>
+
+    <div id="borderarea">
+      <div id="playarea">
+           <canvas id="screen"></canvas>
+           <canvas id="ghost"></canvas>
+           <div id ="celImages">
+             <celImages>
+               <img src="/${dir}/${cel-name}.png" id="${cel-name}" />
+             </celImages>
+           </div>
+      </div>
+    </div>
+
+    <div id="footer">
+      <p>All sets are © their original artists. Learn more about Smooch <a href="https://github.com/emhoracek/smooch">from the Github repo</a>.</p>
+    </div>
+
+    </div>
+
+    <script type="text/javascript" src="/${base}/setdata.js"></script>
+
+    <script type="text/javascript" src="/static/doll.js"></script>
+  </body>
+</html>

--- a/app/templates/users/show.tpl
+++ b/app/templates/users/show.tpl
@@ -32,7 +32,7 @@
 
     <h2>Upload a set</h2>
 
-    <form action="/upload" method="post" enctype="multipart/form-data">
+    <form action="/users/${username}/upload" method="post" enctype="multipart/form-data">
 
       <input type="file" name="kissfile">
       <input type="submit" value="Upload!">

--- a/app/templates/users/show.tpl
+++ b/app/templates/users/show.tpl
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <title>
+      User page
+    </title>
+  </head>
+
+  <body>
+
+    <h1>Welcome, <username /></h1>
+
+    <h2>Your sets</h2>
+
+    <!-- Contirbutors: the bind tag below is a weird hack to get around a
+         a limitation in the Larceny templating system. -->
+    <bind tag="any-sets"><sets><setName /></sets></bind>
+
+    <if exists="${any-sets}">
+      <then>
+        <ul>
+          <sets>
+            <li><a href="sets/${setName}"><setName /></a></li>
+          </sets>
+        </ul>
+      </then>
+      <else>
+        <p>You don't have any sets, so try uploading one.</p>
+      </else>
+    </if>
+
+    <h2>Upload a set</h2>
+
+    <form action="/upload" method="post" enctype="multipart/form-data">
+
+      <input type="file" name="kissfile">
+      <input type="submit" value="Upload!">
+
+    </form>
+
+  </body>
+</html>


### PR DESCRIPTION
Fixes #40.

This removes the public-accessible upload form and sets. A random, unauthenticated user can't upload a doll anymore. Instead, the user has to log in. Also, any doll they upload is only visible to them. (Dolls are called "sets" in the code, as many sets were not actually dolls.)

Made lots of improvements to sessions with this PR. Also really proud of the `requireAuthentication` handler helper. I may pull out a lot of this session stuff to a library.

Still lots of issues. Using the filesystem as a "database" isn't great here. :) It's also annoying to manually test uploads now, especially since sessions vanish when the server restarts. But, this PR is already too big! I will make separate issues for those things.