### PR TITLE
Fix duplicate field labels

### DIFF
--- a/app/src/Kiss.hs
+++ b/app/src/Kiss.hs
@@ -6,7 +6,7 @@ import           Data.Aeson hiding (Array)
 import           Data.Array (Array)
 
 data KissSet = KissSet { kData    :: CNFKissData
-                       , kCels   :: [CNFKissCel]
+                       , kCnfCels :: [CNFKissCel]
                        , kPalette :: Array Int PaletteFilename
                        } deriving (Eq, Show)
 


### PR DESCRIPTION
We chose to simply rename one of the duplicate field labels instead of using the `DuplicateRecordFields` extension because there doesn't seem to be a compelling need for it. The code already uses a system of prefixes like "cel" and "cnf" for naming field labels, so this is more or less in keeping with the coding style.

This closes #79 (`Kiss.hs` fails to compile (duplicate field label`kCels`)).