### PR TITLE
Palettes, offsets, and positions

### DIFF
--- a/app/src/Kiss.hs
+++ b/app/src/Kiss.hs
@@ -81,7 +81,7 @@ data SetPos = Position {
     deriving (Eq, Show)
 instance ToJSON SetPos where
     toJSON (Position x y) = object ["x" .= x, "y" .= y]
-    toJSON NoPosition     = "no object"
+    toJSON NoPosition     = object ["x" .= (0 :: Int), "y" .= (0 :: Int)]
 
 type PaletteFilename = String
 type CelFilename = String

--- a/app/src/Sets/View.hs
+++ b/app/src/Sets/View.hs
@@ -27,4 +27,5 @@ celsSplice dir cels =
 celImageSplice :: FilePath -> KissCel -> Substitutions Ctxt
 celImageSplice dir cel =
   subs [("cel-name", textFill $ T.pack $ celName cel)
-       ,("dir", textFill $ T.pack dir)]
+       ,("pal-num", textFill $ T.pack $ show $ celPalette cel)
+       ,("dir", textFill $ T.pack dir <> "/palette" <> T.pack (show $ celPalette cel))]

--- a/app/src/Upload.hs
+++ b/app/src/Upload.hs
@@ -107,7 +107,9 @@ createCels staticDir = do
           let celFile = base <> "/" <> cel <> ".cel"
           celData <- liftIO $ BS.readFile celFile
           (celHeader, celPixels) <- PC.parseCel celData
-          let pngFile = base <> "/" <> cel <> ".png"
+          let palDir = base <> "/palette" <> show palNum
+          liftIO $ createDirectoryIfMissing True palDir
+          let pngFile = palDir <> "/" <> cel <> ".png"
           liftIO $ celToPng pngFile palData celHeader celPixels
           let xOffset = fromIntegral $ PC.celXoffset celHeader
           let yOffset = fromIntegral $ PC.celYoffset celHeader

--- a/app/templates/users/kiss-set.tpl
+++ b/app/templates/users/kiss-set.tpl
@@ -31,7 +31,7 @@
            <canvas id="ghost"></canvas>
            <div id ="celImages">
              <celImages>
-               <img src="/${dir}/${cel-name}.png" id="${cel-name}" />
+               <img src="/${dir}/${cel-name}.png" id="${cel-name}-${pal-num}" />
              </celImages>
            </div>
       </div>

--- a/javascript/dragAndDrop.js
+++ b/javascript/dragAndDrop.js
@@ -1,4 +1,3 @@
-
 class DragAndDrop {
   constructor (doll) {
     this.dragHandler = false

--- a/javascript/kissCel.js
+++ b/javascript/kissCel.js
@@ -11,7 +11,7 @@ class KiSSCel {
     this.position = obj.positions[0]
     this.positions = obj.positions
     this.sets = cel.sets
-    this.image = document.getElementById(this.name)
+    this.image = document.getElementById(cel.name + '-' + cel.palette)
     this.ghostImage = undefined
     this.visible = false
     this.alpha = cel.alpha

--- a/javascript/kissDoll.js
+++ b/javascript/kissDoll.js
@@ -99,7 +99,7 @@ class KiSSDoll {
     } else {
       const objIndex = this.colorids[colorid]
       const obj = this.objs[objIndex]
-      if (obj && obj.cels[0].fix < 1) {
+      if (obj && !obj.fixed) {
         return obj
       }
     }

--- a/javascript/kissObject.js
+++ b/javascript/kissObject.js
@@ -19,6 +19,10 @@ class KiSSObject {
     return this.positions[this.currentSet]
   }
 
+  get fixed () {
+    return this.cels.some(c => c.fix > 0)
+  }
+
   setPosition (x, y) {
     this.positions[this.currentSet].x = x
     this.positions[this.currentSet].y = y

--- a/javascript/screen.css
+++ b/javascript/screen.css
@@ -14,6 +14,7 @@ canvas {
   image-rendering: -webkit-crisp-edges;
   image-rendering: pixelated;
   image-rendering: crisp-edges;
+  border: 2px inset lightgray
 }
 
 body {
@@ -155,7 +156,6 @@ a.set:hover {
 
 #playarea {
   background: white;
-  border: 1px solid black;
   margin: auto;
 }
 


### PR DESCRIPTION
Fixes #10. 

Many sets will have the same cel file multiple times with different palettes applied. Previously, Smooch would convert the cel for each palette, overwriting the previous conversion. Now we save the converted pngs to separate directories for each palette. You might think (like I did!) that this would mean Smooch sets would be much larger than the original KiSS doll. That's not the case! Lucca is 208K as an LHA file, but the uncompressed cels and palettes total over 1 MB. Meanwhile, the all the PNGs for Lucca are only 620K! The magic of modern image compression! 🎉 

The list comprehension that joined cels and offsets was buggy (creating many duplicate cels) so I simplified it by returning each cel with its own offset instead of trying to match them up later.

I also put the default position back for the JSON rendering of `NoPosition`. I thought `*` meant that there is no object at the instance, and it can mean that, but apparently it can also mean that there is an object at that index, but its position is 0,0. Go figure.

