### PR TITLE
Fix lha decompression

### DIFF
--- a/app/exe/Main.hs
+++ b/app/exe/Main.hs
@@ -5,7 +5,6 @@ module Main where
 
 import           Control.Exception        (SomeException (..), catch)
 import           Control.Logging
-import           Data.Monoid              ((<>))
 import qualified Data.Text                as T
 import           Network.Wai.Handler.Warp
 import           System.Environment

--- a/app/src/ParseCNF.hs
+++ b/app/src/ParseCNF.hs
@@ -89,10 +89,10 @@ parseCel :: Parser CNFKissCel
 parseCel = do
     mark <- many1 digit
     fix <- option 0 parseFix
-    skipMany1 space
+    skipMany1 spaceOrTab
     file <- many1 (noneOf ". ")
     string ".cel" <?> "cel file extension"
-    skipMany1 space
+    skipMany1 spaceOrTab
     palette <- option 0 (try parseCelPalette)
     spacesOrTabs
     sets <- option [0..9] parseSets

--- a/app/src/Upload.hs
+++ b/app/src/Upload.hs
@@ -11,10 +11,8 @@ import           Data.Text                  (Text)
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
 import           Data.Text.ICU.Convert
-
 import           System.Directory
 import           System.FilePath            (takeBaseName, takeExtension, (</>))
-
 import           Control.Exception
 import           Control.Logging            (log')
 import           Control.Monad              (when, void)

--- a/app/src/Web.hs
+++ b/app/src/Web.hs
@@ -5,7 +5,6 @@ module Web where
 import           Control.Lens               ((^.))
 import qualified Data.Configurator          as C
 import           Data.Maybe                 (fromMaybe)
-import           Data.Monoid                ((<>))
 import           Data.Pool                  (createPool)
 import           Data.Text                  (Text)
 import qualified Data.Vault.Lazy            as V


### PR DESCRIPTION
Fixes #100.

Still don't really understand what the bug is here, but when I switched `createProcess` for the simpler `callProcess`, it stopped hanging while decompressing the LHA archive. 

I also fixed a couple of instances of `space` that I missed earlier. They were causing trouble with cel lines that didn't list any palettes or sets.