### PR TITLE
String arguments can be empty strings

### DIFF
--- a/app/smooch.cabal
+++ b/app/smooch.cabal
@@ -123,6 +123,7 @@ test-suite tests
                        array,
                        base16-bytestring,
                        bytestring,
+                       charsetdetect,
                        configurator,
                        cookie,
                        cryptohash-md5,

--- a/app/src/ParseCNF.hs
+++ b/app/src/ParseCNF.hs
@@ -266,7 +266,7 @@ parseFKiSSArg = parseObj <|> parseString <|> parseNumber
             Object . read <$> many1 digit
           parseString = do
             char '"'
-            str <- many1 (noneOf "\"")
+            str <- many (noneOf "\"")
             char '"'
             return (Text str)
           parseNumber = do


### PR DESCRIPTION
Fixes #120.